### PR TITLE
Change meeting link

### DIFF
--- a/src/Events.js
+++ b/src/Events.js
@@ -42,7 +42,7 @@ function generateGbms(startDate, endDate, countOffset = 1, limit = 10) {
 			desc: `Come join us as we construct a mobile app that can pull text from images. Starting at 9:00 pm on ${date.format(
 				"MMM. D"
 			)}`,
-			meetingLink: "https://stevens.zoom.us/j/98789531305",
+			meetingLink: "https://discord.gg/nr3tqCfR2a",
 			startDate: date.hour(21),
 			endDate: date.hour(22),
 			isGbm: true,


### PR DESCRIPTION
Changes the meeting link for GBMs to an invite to the discord server, which is where remote attendees for GBMs will now be directed to.