### PR TITLE
engine restrictions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       working-directory: .
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}
@@ -42,7 +42,7 @@ jobs:
       working-directory: .
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
     steps:
     - name: Checkout Repo
       uses: actions/checkout@master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Deploy
       run: |
-        npm install -g firebase-tools
+        npm install -g firebase-tools@11.16.0
         cd ${{ env.working-directory }}
         firebase deploy --token ${{ secrets.FIREBASE_TOKEN }} --non-interactive

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
       CI: true
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       working-directory: .
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "sec.club",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "14"
+  },
   "dependencies": {
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",


### PR DESCRIPTION
- restrict node version to 14
- update CI to use node 14
- pin version for firebase-tools in CI

This makes it so that you get a warning if you try to use anything other than node 14. This also updates all the CI jobs to use node 14 instead of 12.
